### PR TITLE
Extract Sentinel-2 collection helpers to dedicated script

### DIFF
--- a/resources/js/sentinel-collections.js
+++ b/resources/js/sentinel-collections.js
@@ -61,6 +61,10 @@ const createSentinelCard = (feature, template) => {
     const detailEl = clone.querySelector("[data-sentinel-details]");
     const previewLink = clone.querySelector("[data-sentinel-preview]");
     const openLink = clone.querySelector("[data-sentinel-open]");
+    const thumbnailImage = clone.querySelector("[data-sentinel-thumbnail-image]");
+    const thumbnailPlaceholder = clone.querySelector(
+        "[data-sentinel-thumbnail-placeholder]"
+    );
 
     const shortenText =
         typeof window?.shortenFilename === "function"
@@ -126,6 +130,23 @@ const createSentinelCard = (feature, template) => {
         (typeof feature?.id === "string" && feature.id.startsWith("http")
             ? feature.id
             : null);
+
+    if (thumbnailImage) {
+        if (quicklookUrl) {
+            thumbnailImage.src = quicklookUrl;
+            thumbnailImage.classList.remove("hidden");
+            thumbnailImage.alt = `Preview of ${productText}`;
+            if (thumbnailPlaceholder) {
+                thumbnailPlaceholder.classList.add("hidden");
+            }
+        } else {
+            thumbnailImage.removeAttribute("src");
+            thumbnailImage.classList.add("hidden");
+            if (thumbnailPlaceholder) {
+                thumbnailPlaceholder.classList.remove("hidden");
+            }
+        }
+    }
 
     if (previewLink) {
         if (quicklookUrl) {

--- a/resources/js/sentinel-collections.js
+++ b/resources/js/sentinel-collections.js
@@ -1,0 +1,257 @@
+const sentinelCatalogEndpoint =
+    "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json";
+
+const formatISODate = (date) => {
+    if (!(date instanceof Date)) return "";
+    const copy = new Date(date.getTime());
+    copy.setMinutes(copy.getMinutes() - copy.getTimezoneOffset());
+    return copy.toISOString().split("T")[0];
+};
+
+const formatReadableDate = (value) => {
+    if (!value) return "Unknown date";
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return value;
+    return (
+        parsed.toLocaleString("id-ID", {
+            dateStyle: "medium",
+            timeStyle: "short",
+            timeZone: "UTC",
+        }) + " UTC"
+    );
+};
+
+const formatCloudCover = (value) => {
+    if (typeof value === "number" && !Number.isNaN(value)) {
+        return `${value.toFixed(1)}%`;
+    }
+    return "N/A";
+};
+
+const attemptFetch = async (targetUrl) => {
+    const response = await fetch(targetUrl);
+    if (!response.ok) {
+        throw new Error(`Status ${response.status}`);
+    }
+    return response.json();
+};
+
+const fetchSentinelCatalog = async (url) => {
+    try {
+        return await attemptFetch(url);
+    } catch (err) {
+        const proxyUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(
+            url
+        )}`;
+        return await attemptFetch(proxyUrl);
+    }
+};
+
+const createSentinelCard = (feature, template) => {
+    if (!template) return null;
+
+    const clone = template.content.cloneNode(true);
+    const props = feature?.properties ?? {};
+    const links = feature?.links ?? [];
+    const assets = feature?.assets ?? {};
+
+    const titleEl = clone.querySelector("[data-sentinel-title]");
+    const productEl = clone.querySelector("[data-sentinel-product]");
+    const datetimeEl = clone.querySelector("[data-sentinel-datetime]");
+    const detailEl = clone.querySelector("[data-sentinel-details]");
+    const previewLink = clone.querySelector("[data-sentinel-preview]");
+    const openLink = clone.querySelector("[data-sentinel-open]");
+
+    const shortenText =
+        typeof window?.shortenFilename === "function"
+            ? (value, max = 40) => window.shortenFilename(String(value), max)
+            : (value) => String(value ?? "");
+
+    const productId =
+        props.productIdentifier ||
+        props.title ||
+        feature?.id ||
+        "Sentinel-2 Product";
+    const acquisitionDate =
+        props.completionDate ||
+        props.startDate ||
+        props.endPosition ||
+        props.beginPosition ||
+        props.startTimeFromAscendingNode;
+    const mgrsIdentifier = props.mgrsId || props.tileId || props.MGRS;
+    const tileText = mgrsIdentifier ? `Tile ${mgrsIdentifier}` : null;
+    const cloudCover =
+        props.cloudCover ??
+        props["cloudcoverpercentage"] ??
+        props["cloudCoverageAssessment"];
+
+    const titleText = shortenText(props.title) || shortenText(productId);
+    const productText = productId;
+
+    if (titleEl) {
+        titleEl.textContent = shortenText(titleText, 48);
+        titleEl.setAttribute("title", titleText);
+    }
+
+    if (productEl) {
+        productEl.textContent = shortenText(productText, 44);
+        productEl.setAttribute("title", productText);
+    }
+
+    if (datetimeEl)
+        datetimeEl.textContent = `Acquired: ${formatReadableDate(
+            acquisitionDate
+        )}`;
+
+    const detailParts = [];
+    if (tileText) detailParts.push(tileText);
+    if (cloudCover !== undefined)
+        detailParts.push(`Cloud cover: ${formatCloudCover(Number(cloudCover))}`);
+    if (props.collection) detailParts.push(`Collection: ${props.collection}`);
+
+    if (detailEl) {
+        detailEl.textContent = detailParts.length
+            ? detailParts.join(" • ")
+            : "No additional metadata available";
+    }
+
+    const quicklookUrl =
+        props.quicklook ||
+        assets?.thumbnail?.href ||
+        assets?.overview?.href ||
+        links.find((link) => link.rel === "preview")?.href;
+    const openUrl =
+        props.services?.download?.url ||
+        links.find((link) => link.rel === "self")?.href ||
+        (typeof feature?.id === "string" && feature.id.startsWith("http")
+            ? feature.id
+            : null);
+
+    if (previewLink) {
+        if (quicklookUrl) {
+            previewLink.href = quicklookUrl;
+            previewLink.classList.remove("hidden");
+        } else {
+            previewLink.classList.add("hidden");
+        }
+    }
+
+    if (openLink) {
+        if (openUrl) {
+            openLink.href = openUrl;
+        } else {
+            openLink.href = `https://dataspace.copernicus.eu/browser/?product=${encodeURIComponent(
+                productId
+            )}`;
+        }
+    }
+
+    return clone;
+};
+
+export function initSentinelCollections({
+    sentinelStatus,
+    sentinelList,
+    sentinelTemplate,
+    sentinelLastUpdated,
+    sentinelRefreshButton,
+} = {}) {
+    let sentinelLoadedOnce = false;
+
+    if (!sentinelStatus || !sentinelList || !sentinelTemplate) {
+        return {
+            loadSentinelCollections: () => {},
+            hasLoadedOnce: () => sentinelLoadedOnce,
+        };
+    }
+
+    const loadSentinelCollections = async (forceRefresh = false) => {
+        if (forceRefresh && window.MyZkToast?.info) {
+            window.MyZkToast.info("Refreshing Sentinel-2 catalogue...");
+        }
+
+        sentinelStatus.classList.remove("hidden");
+        sentinelStatus.textContent = "Fetching latest Sentinel-2 collections...";
+        sentinelList.innerHTML = "";
+
+        const endDate = new Date();
+        const startDate = new Date(endDate);
+        startDate.setMonth(startDate.getMonth() - 1);
+        startDate.setHours(0, 0, 0, 0);
+        const endDateAdjusted = new Date(endDate);
+        endDateAdjusted.setHours(23, 59, 59, 999);
+
+        const params = new URLSearchParams({
+            startDate: formatISODate(startDate),
+            completionDate: formatISODate(endDateAdjusted),
+            maxRecords: "20",
+            productType: "S2MSI2A",
+            sortParam: "startDate",
+            sortOrder: "descending",
+        });
+
+        const requestUrl = `${sentinelCatalogEndpoint}?${params.toString()}`;
+
+        try {
+            const response = await fetchSentinelCatalog(requestUrl);
+            const features = Array.isArray(response?.features)
+                ? response.features
+                : [];
+
+            if (!features.length) {
+                sentinelStatus.textContent =
+                    "No Sentinel-2 collections found in the last 30 days.";
+            } else {
+                sentinelStatus.classList.add("hidden");
+                features.forEach((feature) => {
+                    const card = createSentinelCard(feature, sentinelTemplate);
+                    if (card) {
+                        sentinelList.appendChild(card);
+                    }
+                });
+            }
+
+            sentinelLoadedOnce = true;
+
+            if (sentinelLastUpdated) {
+                sentinelLastUpdated.textContent = new Date().toLocaleString(
+                    "id-ID"
+                );
+            }
+
+            if (features.length && forceRefresh && window.MyZkToast?.success) {
+                window.MyZkToast.success("Sentinel-2 collections updated.");
+            }
+        } catch (error) {
+            const message = error?.message ? ` (${error.message})` : "";
+            sentinelStatus.classList.remove("hidden");
+            sentinelStatus.textContent = `Unable to fetch Sentinel-2 collections${message}. Please try again later.`;
+
+            if (sentinelLastUpdated) {
+                sentinelLastUpdated.textContent = new Date().toLocaleString(
+                    "id-ID"
+                );
+            }
+
+            if (window.MyZkToast?.error) {
+                window.MyZkToast.error(
+                    "Failed to update Sentinel-2 collections."
+                );
+            }
+        }
+    };
+
+    if (sentinelRefreshButton) {
+        sentinelRefreshButton.addEventListener("click", () =>
+            loadSentinelCollections(true)
+        );
+    }
+
+    return {
+        loadSentinelCollections,
+        hasLoadedOnce: () => sentinelLoadedOnce,
+    };
+}
+
+window.initSentinelCollections = initSentinelCollections;
+

--- a/resources/views/layouts/app-front-map.blade.php
+++ b/resources/views/layouts/app-front-map.blade.php
@@ -44,7 +44,13 @@
             })();
         </script>
         <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-        @vite(['resources/css/app.css', 'resources/css/map.css', 'resources/js/app.js', 'resources/js/map.js'])
+        @vite([
+            'resources/css/app.css',
+            'resources/css/map.css',
+            'resources/js/app.js',
+            'resources/js/map.js',
+            'resources/js/sentinel-collections.js',
+        ])
     </head>
 
     @php

--- a/resources/views/pages/front/appMap.blade.php
+++ b/resources/views/pages/front/appMap.blade.php
@@ -1018,195 +1018,21 @@
             const sentinelLastUpdated = document.getElementById('sentinelLastUpdated');
             const sentinelRefreshButton = document.getElementById('sentinelRefreshButton');
 
-            const sentinelCatalogEndpoint = 'https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json';
-            let sentinelLoadedOnce = false;
-
             const scrollAmount = 150; // pixels per click
 
-            const formatISODate = (date) => {
-                if (!(date instanceof Date)) return '';
-                const copy = new Date(date.getTime());
-                copy.setMinutes(copy.getMinutes() - copy.getTimezoneOffset());
-                return copy.toISOString().split('T')[0];
-            };
+            const sentinelCollectionsModule =
+                typeof window !== 'undefined' && typeof window.initSentinelCollections === 'function'
+                    ? window.initSentinelCollections({
+                        sentinelStatus,
+                        sentinelList,
+                        sentinelTemplate,
+                        sentinelLastUpdated,
+                        sentinelRefreshButton,
+                    })
+                    : null;
 
-            const formatReadableDate = (value) => {
-                if (!value) return 'Unknown date';
-                const parsed = new Date(value);
-                if (Number.isNaN(parsed.getTime())) return value;
-                return parsed.toLocaleString('id-ID', {
-                    dateStyle: 'medium',
-                    timeStyle: 'short',
-                    timeZone: 'UTC'
-                }) + ' UTC';
-            };
-
-            const formatCloudCover = (value) => {
-                if (typeof value === 'number' && !Number.isNaN(value)) {
-                    return `${value.toFixed(1)}%`;
-                }
-                return 'N/A';
-            };
-
-            async function fetchSentinelCatalog(url) {
-                const attemptFetch = async (targetUrl) => {
-                    const response = await fetch(targetUrl);
-                    if (!response.ok) {
-                        throw new Error(`Status ${response.status}`);
-                    }
-                    return response.json();
-                };
-
-                try {
-                    return await attemptFetch(url);
-                } catch (err) {
-                    const proxyUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`;
-                    return await attemptFetch(proxyUrl);
-                }
-            }
-
-            function createSentinelCard(feature) {
-                if (!sentinelTemplate) return null;
-
-                const clone = sentinelTemplate.content.cloneNode(true);
-                const props = feature?.properties ?? {};
-                const links = feature?.links ?? [];
-                const assets = feature?.assets ?? {};
-
-                const titleEl = clone.querySelector('[data-sentinel-title]');
-                const productEl = clone.querySelector('[data-sentinel-product]');
-                const datetimeEl = clone.querySelector('[data-sentinel-datetime]');
-                const detailEl = clone.querySelector('[data-sentinel-details]');
-                const previewLink = clone.querySelector('[data-sentinel-preview]');
-                const openLink = clone.querySelector('[data-sentinel-open]');
-
-                const shortenText = typeof window?.shortenFilename === 'function' ?
-                    (value, max = 40) => window.shortenFilename(String(value), max) :
-                    (value) => String(value ?? '');
-
-                const productId = props.productIdentifier || props.title || feature?.id || 'Sentinel-2 Product';
-                const acquisitionDate = props.completionDate || props.startDate || props.endPosition || props.beginPosition || props.startTimeFromAscendingNode;
-                const mgrsIdentifier = props.mgrsId || props.tileId || props.MGRS;
-                const tileText = mgrsIdentifier ? `Tile ${mgrsIdentifier}` : null;
-                const cloudCover = props.cloudCover ?? props['cloudcoverpercentage'] ?? props['cloudCoverageAssessment'];
-
-                const titleText = shortenFilename(props.title) || shortenFilename(productId);
-                const productText = productId;
-
-                if (titleEl) {
-                    titleEl.textContent = shortenText(titleText, 48);
-                    titleEl.setAttribute('title', titleText);
-                }
-
-                if (productEl) {
-                    productEl.textContent = shortenText(productText, 44);
-                    productEl.setAttribute('title', productText);
-                }
-                if (datetimeEl) datetimeEl.textContent = `Acquired: ${formatReadableDate(acquisitionDate)}`;
-
-                const detailParts = [];
-                if (tileText) detailParts.push(tileText);
-                if (cloudCover !== undefined) detailParts.push(`Cloud cover: ${formatCloudCover(Number(cloudCover))}`);
-                if (props.collection) detailParts.push(`Collection: ${props.collection}`);
-                if (detailEl) {
-                    detailEl.textContent = detailParts.length ? detailParts.join(' • ') : 'No additional metadata available';
-                }
-
-                const quicklookUrl = props.quicklook || assets?.thumbnail?.href || assets?.overview?.href || links.find(link => link.rel === 'preview')?.href;
-                const openUrl = props.services?.download?.url || links.find(link => link.rel === 'self')?.href || (typeof feature?.id === 'string' && feature.id.startsWith('http') ? feature.id : null);
-
-                if (previewLink) {
-                    if (quicklookUrl) {
-                        previewLink.href = quicklookUrl;
-                        previewLink.classList.remove('hidden');
-                    } else {
-                        previewLink.classList.add('hidden');
-                    }
-                }
-
-                if (openLink) {
-                    if (openUrl) {
-                        openLink.href = openUrl;
-                    } else {
-                        openLink.href = `https://dataspace.copernicus.eu/browser/?product=${encodeURIComponent(productId)}`;
-                    }
-                }
-
-                return clone;
-            }
-
-            async function loadSentinelCollections(forceRefresh = false) {
-                if (!sentinelStatus || !sentinelList) return;
-
-                if (forceRefresh && window.MyZkToast?.info) {
-                    window.MyZkToast.info('Refreshing Sentinel-2 catalogue...');
-                }
-
-                sentinelStatus.classList.remove('hidden');
-                sentinelStatus.textContent = 'Fetching latest Sentinel-2 collections...';
-                sentinelList.innerHTML = '';
-
-                const endDate = new Date();
-                const startDate = new Date(endDate);
-                startDate.setMonth(startDate.getMonth() - 1);
-                startDate.setHours(0, 0, 0, 0);
-                const endDateAdjusted = new Date(endDate);
-                endDateAdjusted.setHours(23, 59, 59, 999);
-
-                const params = new URLSearchParams({
-                    startDate: formatISODate(startDate),
-                    completionDate: formatISODate(endDateAdjusted),
-                    maxRecords: '20',
-                    productType: 'S2MSI2A',
-                    sortParam: 'startDate',
-                    sortOrder: 'descending'
-                });
-
-                const requestUrl = `${sentinelCatalogEndpoint}?${params.toString()}`;
-
-                try {
-                    const response = await fetchSentinelCatalog(requestUrl);
-                    const features = Array.isArray(response?.features) ? response.features : [];
-
-                    if (!features.length) {
-                        sentinelStatus.textContent = 'No Sentinel-2 collections found in the last 30 days.';
-                    } else {
-                        sentinelStatus.classList.add('hidden');
-                        features.forEach(feature => {
-                            const card = createSentinelCard(feature);
-                            if (card) {
-                                sentinelList.appendChild(card);
-                            }
-                        });
-                    }
-
-                    sentinelLoadedOnce = true;
-
-                    if (sentinelLastUpdated) {
-                        sentinelLastUpdated.textContent = new Date().toLocaleString('id-ID');
-                    }
-
-                    if (features.length && forceRefresh && window.MyZkToast?.success) {
-                        window.MyZkToast.success('Sentinel-2 collections updated.');
-                    }
-                } catch (error) {
-                    const message = error?.message ? ` (${error.message})` : '';
-                    sentinelStatus.classList.remove('hidden');
-                    sentinelStatus.textContent = `Unable to fetch Sentinel-2 collections${message}. Please try again later.`;
-
-                    if (sentinelLastUpdated) {
-                        sentinelLastUpdated.textContent = new Date().toLocaleString('id-ID');
-                    }
-
-                    if (window.MyZkToast?.error) {
-                        window.MyZkToast.error('Failed to update Sentinel-2 collections.');
-                    }
-                }
-            }
-
-            if (sentinelRefreshButton) {
-                sentinelRefreshButton.addEventListener('click', () => loadSentinelCollections(true));
-            }
+            const loadSentinelCollections = sentinelCollectionsModule?.loadSentinelCollections ?? (() => {});
+            const hasSentinelLoadedOnce = sentinelCollectionsModule?.hasLoadedOnce ?? (() => false);
 
             scrollLeftBtn.addEventListener('click', () => {
                 scrollContainer.scrollBy({
@@ -1281,7 +1107,7 @@
 
                 panelWrapper.dataset.activePanel = id;
 
-                if (id === 'sentinel-panel' && !sentinelLoadedOnce) {
+                if (id === 'sentinel-panel' && !hasSentinelLoadedOnce()) {
                     loadSentinelCollections();
                 }
             }
@@ -1321,7 +1147,7 @@
 
                 showPanel(defaultPanel, defaultBtn);
 
-                if (!sentinelLoadedOnce) {
+                if (!hasSentinelLoadedOnce()) {
                     loadSentinelCollections();
                 }
             });

--- a/resources/views/pages/front/appMap.blade.php
+++ b/resources/views/pages/front/appMap.blade.php
@@ -206,11 +206,17 @@
 
                 <template id="sentinelCollectionTemplate">
                     <div class="sentinel-card border-foreground/20 bg-background/60 flex flex-col rounded-xl border p-3 shadow-sm transition-all duration-200 hover:shadow-md">
-                        <div class="flex flex-col space-y-1">
-                            <p class="text-foreground text-sm font-semibold" data-sentinel-title>Sentinel-2 Tile</p>
-                            <p class="text-foreground/70 text-xs" data-sentinel-product>Product ID</p>
-                            <p class="text-foreground/80 text-xs" data-sentinel-datetime>Acquired:</p>
-                            <p class="text-foreground/60 text-xs" data-sentinel-details>Tile • Cloud cover</p>
+                        <div class="flex items-start gap-3">
+                            <div class="bg-foreground/5 sentinel-thumbnail relative flex h-20 w-20 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg" data-sentinel-thumbnail>
+                                <img class="hidden h-full w-full object-cover" data-sentinel-thumbnail-image alt="Sentinel-2 preview" />
+                                <i class="ri-image-line text-foreground/40 text-2xl" data-sentinel-thumbnail-placeholder></i>
+                            </div>
+                            <div class="flex flex-1 flex-col space-y-1">
+                                <p class="text-foreground text-sm font-semibold" data-sentinel-title>Sentinel-2 Tile</p>
+                                <p class="text-foreground/70 text-xs" data-sentinel-product>Product ID</p>
+                                <p class="text-foreground/80 text-xs" data-sentinel-datetime>Acquired:</p>
+                                <p class="text-foreground/60 text-xs" data-sentinel-details>Tile • Cloud cover</p>
+                            </div>
                         </div>
                         <div class="mt-3 flex flex-wrap gap-2" data-sentinel-actions>
                             <a class="hover:bg-primary/10 text-primary border-primary/40 inline-flex items-center space-x-1 rounded-lg border px-2 py-1 text-xs font-medium" data-sentinel-preview target="_blank" rel="noopener">


### PR DESCRIPTION
## Summary
- move the Sentinel-2 collection helper functions into a dedicated Vite module
- wire the new module into the front map layout and page to keep existing behaviours intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e3d753c5588324b7176ff967ecda45